### PR TITLE
Fixed error in readRegister protocol

### DIFF
--- a/src/SparkFunTMP102.cpp
+++ b/src/SparkFunTMP102.cpp
@@ -53,7 +53,6 @@ uint8_t TMP102::readRegister(bool registerNumber){
   
   // Read current configuration register value
   Wire.requestFrom(_address, 2); 	// Read two bytes from TMP102
-  Wire.endTransmission();
   registerByte[0] = (Wire.read());	// Read first byte
   registerByte[1] = (Wire.read());	// Read second byte
   

--- a/src/SparkFunTMP102.cpp
+++ b/src/SparkFunTMP102.cpp
@@ -20,7 +20,6 @@ local, and you've found our code helpful, please buy us a round!
 Distributed as-is; no warranty is given.
 ******************************************************************************/
 #include "SparkFunTMP102.h"
-#include <Wire.h>
 
 #define TEMPERATURE_REGISTER 0x00
 #define CONFIG_REGISTER 0x01

--- a/src/SparkFunTMP102.h
+++ b/src/SparkFunTMP102.h
@@ -20,12 +20,21 @@ Distributed as-is; no warranty is given.
 #ifndef TMP102_h
 #define TMP102_h
 
-#if defined(ARDUINO) && ARDUINO >= 100
- #include "Arduino.h"
+// This library can now be built for Particle Photo, Partical Electron, and Bluz
+#if PLATFORM_ID == 103 || PLATFORM_ID == 10 || PLATFORM_ID == 6
+	#include "spark_wiring_usbserial.h"
+	#include "spark_wiring_i2c.h"
+	#include "spark_wiring_constants.h"
 #else
- #include "WProgram.h"
+	// Arduino Platforms
+	#if defined(ARDUINO) && ARDUINO >= 100
+ 		#include "Arduino.h"
+	#else
+ 		#include "WProgram.h"
+	#endif
+	#include "Wire.h"
 #endif
-#include <Wire.h>
+
 class TMP102
 {
 	public:

--- a/src/SparkFunTMP102.h
+++ b/src/SparkFunTMP102.h
@@ -77,7 +77,7 @@ class TMP102
 	private:
 		int _address; // Address of Temperature sensor (0x48,0x49,0x4A,0x4B)
 		void openPointerRegister(byte pointerReg); // Changes the pointer register
-		byte readRegister(bool registerNumber);	// reads 1 byte of from register
+		byte TMP102::readRegisters(uint8_t *registerBytes);  // reads 2 bytes from register
 };
 
 


### PR DESCRIPTION
readRegister() had an extraneous Wire.endTransmission() call in it that prevented the code from having the actual register contents.  This caused the library to only read one temperature, and most of the time that temperature fluctuated greatly from the actual temp.